### PR TITLE
Update AG2 names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ server.
 
 ## Useful Links 🔗
 
-- **Full Guide:** Microsoft's GraphRAG + AutoGen + Ollama + Chainlit = Fully Local & Free Multi-Agent RAG Superbot [Medium.com](https://medium.com/@karthik.codex/microsofts-graphrag-autogen-ollama-chainlit-fully-local-free-multi-agent-rag-superbot-61ad3759f06f) 📚
+- **Full Guide:** Microsoft's GraphRAG + AG2 (Formerly AutoGen) + Ollama + Chainlit = Fully Local & Free Multi-Agent RAG Superbot [Medium.com](https://medium.com/@karthik.codex/microsofts-graphrag-autogen-ollama-chainlit-fully-local-free-multi-agent-rag-superbot-61ad3759f06f) 📚
 
 ## 📦 Installation and Setup Linux
 
-Follow these steps to set up and run AutoGen GraphRAG Local with Ollama and Chainlit UI:
+Follow these steps to set up and run AG2 GraphRAG Local with Ollama and Chainlit UI:
 
 1. **Install LLMs:**
 
@@ -66,7 +66,7 @@ Follow these steps to set up and run AutoGen GraphRAG Local with Ollama and Chai
 
 ## 📦 Installation and Setup Windows
 
-Follow these steps to set up and run AutoGen GraphRAG Local with Ollama and Chainlit UI on Windows:
+Follow these steps to set up and run AG2's GraphRAG Local with Ollama and Chainlit UI on Windows:
 
 1. **Install LLMs:**
 

--- a/chainlit.md
+++ b/chainlit.md
@@ -1,4 +1,4 @@
-# Multi-Agent AI Superbot using AutoGen and GraphRAG
+# Multi-Agent AI Superbot using AG2 and GraphRAG
 
 This application integrates GraphRAG with AutoGen agents, powered by local LLMs from Ollama, for free and offline embedding and inference. Key highlights include:
  - **Agentic-RAG:** - Integrating GraphRAG's knowledge search method with an AutoGen agent via function calling.
@@ -10,4 +10,4 @@ server.
 
 ## Useful Links 🔗
 
-- **Medium Article:** Microsoft's GraphRAG + AutoGen + Ollama + Chainlit = Fully Local & Free Multi-Agent RAG Superbot [Medium.com](https://medium.com/@karthik.codex/microsofts-graphrag-autogen-ollama-chainlit-fully-local-free-multi-agent-rag-superbot-61ad3759f06f) 📚
+- **Medium Article:** Microsoft's GraphRAG + AG2 (Formerly AutoGen) + Ollama + Chainlit = Fully Local & Free Multi-Agent RAG Superbot [Medium.com](https://medium.com/@karthik.codex/microsofts-graphrag-autogen-ollama-chainlit-fully-local-free-multi-agent-rag-superbot-61ad3759f06f) 📚


### PR DESCRIPTION
AutoGen is being evolved into AG2, which is where the package `pyautogen` associated with. AG2 is actively maintained by the founders of AutoGen.
This PR updates the names references to document.

Checkout doc here: https://docs.ag2.ai/docs/Home

Let me know if there are any issues with it!

